### PR TITLE
Add x11 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.15.0-rc.3", default-features = false }
+bevy = { version = "0.15.0-rc.3", default-features = false, features = [ "x11" ] }
 
 [features]
 2d = [


### PR DESCRIPTION
Winit gives an opaque error when trying to build projects that use this as a dependency on X11 systems.